### PR TITLE
Fix error handling of wrapped errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -16,7 +16,7 @@ func Error(errM ...*ErrorMap) gin.HandlerFunc {
 
 		for _, err := range errM {
 			for _, e := range err.errors {
-				if e == lastError.Err || errors.Is(e, lastError.Err) {
+				if e == lastError.Err || errors.Is(lastError.Err, e) {
 					err.response(c)
 				}
 			}

--- a/error.go
+++ b/error.go
@@ -15,10 +15,8 @@ func Error(errM ...*ErrorMap) gin.HandlerFunc {
 		}
 
 		for _, err := range errM {
-			for _, e := range err.errors {
-				if e == lastError.Err || errors.Is(lastError.Err, e) {
-					err.response(c)
-				}
+			if err.matchError(lastError.Err) {
+				err.response(c)
 			}
 		}
 	}
@@ -42,6 +40,15 @@ func (e *ErrorMap) StatusCode(statusCode int) *ErrorMap {
 func (e *ErrorMap) Response(response func(c *gin.Context)) *ErrorMap {
 	e.response = response
 	return e
+}
+
+func (e *ErrorMap) matchError(actual error) bool {
+	for _, expected := range e.errors {
+		if expected == actual || errors.Is(actual, expected) {
+			return true
+		}
+	}
+	return false
 }
 
 func NewErrMap(err ...error) *ErrorMap {

--- a/error.go
+++ b/error.go
@@ -44,7 +44,7 @@ func (e *ErrorMap) Response(response func(c *gin.Context)) *ErrorMap {
 
 func (e *ErrorMap) matchError(actual error) bool {
 	for _, expected := range e.errors {
-		if expected == actual || errors.Is(actual, expected) {
+		if errors.Is(actual, expected) || errors.Is(expected, actual) {
 			return true
 		}
 	}

--- a/error.go
+++ b/error.go
@@ -44,7 +44,7 @@ func (e *ErrorMap) Response(response func(c *gin.Context)) *ErrorMap {
 
 func (e *ErrorMap) matchError(actual error) bool {
 	for _, expected := range e.errors {
-		if errors.Is(actual, expected) || errors.Is(expected, actual) {
+		if errors.Is(actual, expected) {
 			return true
 		}
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -80,3 +80,21 @@ func TestErrToResponse(t *testing.T) {
 		t.Errorf("invalid the response body %+v", rsp.Error)
 	}
 }
+
+func TestErrorMap_matchError(t *testing.T) {
+	t.Run("single error", func(t *testing.T) {
+		em := NewErrMap(BadRequestErr)
+		err := BadRequestErr
+		if em.matchError(err) == false {
+			t.Errorf("error should match")
+		}
+	})
+
+	t.Run("wrapped error", func(t *testing.T) {
+		em := NewErrMap(BadRequestErr)
+		err := fmt.Errorf("%w: Details about this error", BadRequestErr)
+		if em.matchError(err) == false {
+			t.Errorf("error should match")
+		}
+	})
+}

--- a/error_test.go
+++ b/error_test.go
@@ -27,6 +27,22 @@ func TestErrToStatusCode(t *testing.T) {
 	}
 }
 
+// TestWrappedErrToStatusCode ensures that the middleware also works with wrapped errors.
+func TestWrappedErrToStatusCode(t *testing.T) {
+	r := gin.Default()
+	r.Use(Error(NewErrMap(BadRequestErr).StatusCode(http.StatusBadRequest)))
+	r.GET("/test", func(c *gin.Context) {
+		_ = c.Error(fmt.Errorf("%w: this is a wrapped error", BadRequestErr))
+	})
+
+	recorder := httptest.NewRecorder()
+	r.ServeHTTP(recorder, httptest.NewRequest("GET", "/test", nil))
+
+	if recorder.Result().StatusCode != http.StatusBadRequest {
+		t.Errorf("invalid the status code %+v", recorder.Result().StatusCode)
+	}
+}
+
 func TestErrToResponse(t *testing.T) {
 	r := gin.Default()
 	r.Use(Error(


### PR DESCRIPTION
This PR fixes error handling for wrapped errors.

This bug was caused by wrong parameter order in the usage of `errors.Is`

The added test case shows a use case.

@richzw This changes the behaviour of the middleware: Now - errors which may deeply wrap other errors could match in the middleware where they previously didn't. I think this change fixes a bug but maybe you want the behaviour do not change? LMK.